### PR TITLE
Add update to proxy (not just import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Apigee Edge administrative API is just a REST-ful API, so of course any go p
 
 Not in scope:
 
-- OAuth2.0 tokens - Listing, Querying, Approving, Revoking, Deleting, or Updating 
+- OAuth2.0 tokens - Listing, Querying, Approving, Revoking, Deleting, or Updating
 - TargetServers: list, create, edit, etc
 - keystores, truststores: adding certs, listing certs
 - data masks
@@ -44,13 +44,13 @@ This project is a work-in-progress. Here's the status:
 
 | entity type   | implemented              | not implemented yet
 | :------------ | :----------------------- | :--------------------
-| apis          | list, query, inquire revisions, import, export, delete, delete revision, deploy, undeploy, inquire deployment status | 
-| apiproducts   | | list, query, create, delete, modify description, modify approvalType, modify scopes, add or remove proxy, add or remove custom attrs, modify public/private, change quota | 
-| developers    | | list, query, make active or inactive, create, delete, modify custom attrs | 
+| apis          | list, query, inquire revisions, import, export, delete, delete revision, deploy, undeploy, inquire deployment status |
+| apiproducts   | | list, query, create, delete, modify description, modify approvalType, modify scopes, add or remove proxy, add or remove custom attrs, modify public/private, change quota |
+| developers    | | list, query, make active or inactive, create, delete, modify custom attrs |
 | developer app | | list, query, create, delete, revoke, approve, add new credential, remove credential | modify custom attrs
 | credential    | | list, revoke, approve, add apiproduct, remove apiproduct |
 | kvm           | | list, query, create, delete, get all entries, get entry, add entry, modify entry, remove entry
-| cache         | | list, query, create, delete, clear | 
+| cache         | | list, query, create, delete, clear |
 | environment   | | list, query |
 
 Pull requests are welcomed.
@@ -82,19 +82,19 @@ func main() {
 
   if *namePtr != "" {
     proxyName = *namePtr
-  } 
-  
+  }
+
   if *srcPtr == "" || *orgPtr == "" {
     usage()
     return
   }
-  
+
   var auth *apigee.EdgeAuth = nil
-  
+
   // Specifying nil for Auth implies "read from .netrc"
   // Specify a password explicitly like so:
   // auth := apigee.EdgeAuth{Username: "user@example.org", Password: "Secret*123"}
-  
+
   opts := &apigee.EdgeClientOptions{Org: *orgPtr, Auth: auth, Debug: false }
   client, e := apigee.NewEdgeClient(opts)
   if e != nil {
@@ -110,7 +110,7 @@ func main() {
   }
   fmt.Printf("status: %d\n", resp.StatusCode)
   fmt.Printf("status: %s\n", resp.Status)
-  defer resp.Body.Close()  
+  defer resp.Body.Close()
   fmt.Printf("proxyRev: %#v\n", proxyRev)
 
   // TODO: Deploy the proxy revision with override = 10
@@ -119,7 +119,7 @@ func main() {
 
   fmt.Printf("\nWaiting...\n")
   time.Sleep(3 * time.Second)
-  
+
   fmt.Printf("\nDeleting...\n")
   deletedRev, resp, e := client.Proxies.DeleteRevision(proxyRev.Name, proxyRev.Revision)
   if e != nil {
@@ -128,7 +128,7 @@ func main() {
   }
   fmt.Printf("status: %d\n", resp.StatusCode)
   fmt.Printf("status: %s\n", resp.Status)
-  defer resp.Body.Close()  
+  defer resp.Body.Close()
   fmt.Printf("proxyRev: %#v\n", deletedRev)
 }
 
@@ -140,7 +140,7 @@ func main() {
 
 * When importing from a source directory, the library creates a temporary zip file, but doesn't delete the file.
 
-* There is no working code for example clients, included in the distribution here. 
+* There is no working code for example clients, included in the distribution here.
 
 * There is no package versioning strategy (eg, no use of GoPkg.in)
 

--- a/proxies.go
+++ b/proxies.go
@@ -25,7 +25,7 @@ type ProxiesService interface {
 	List() ([]string, *Response, error)
 	Get(string) (*Proxy, *Response, error)
 	Import(string, string) (*ProxyRevision, *Response, error)
-	Update(string, Revision, string) (*ProxyRevisionUpdate, *Response, error)
+	Update(string, string, string) (*ProxyRevisionUpdate, *Response, error)
 	Delete(string) (*DeletedProxyInfo, *Response, error)
 	DeleteRevision(string, Revision) (*ProxyRevision, *Response, error)
 	Deploy(string, string, Revision, int, bool) (*ProxyRevisionDeployment, *Response, error)
@@ -286,8 +286,8 @@ func (s *ProxiesServiceOp) Import(proxyName string, source string) (*ProxyRevisi
 // Update an API proxy revision that already exists.
 // The source can be either a filesystem directory containing an exploded apiproxy bundle, OR
 // the path of a zip file containing an API Proxy bundle. Returns the API proxy revision.
-func (s *ProxiesServiceOp) Update(proxyName string, rev Revision, source string) (*ProxyRevisionUpdate, *Response, error) {
-	path := path.Join(proxiesPath, proxyName, "revisions", fmt.Sprintf("%d", rev))
+func (s *ProxiesServiceOp) Update(proxyName string, rev string, source string) (*ProxyRevisionUpdate, *Response, error) {
+	path := path.Join(proxiesPath, proxyName, "revisions", rev)
 
 	ioreader, err := getZip(proxyName, "Update", source)
 	if err != nil {

--- a/proxies.go
+++ b/proxies.go
@@ -25,6 +25,7 @@ type ProxiesService interface {
 	List() ([]string, *Response, error)
 	Get(string) (*Proxy, *Response, error)
 	Import(string, string) (*ProxyRevision, *Response, error)
+	Update(string, Revision, string) (*ProxyRevisionUpdate, *Response, error)
 	Delete(string) (*DeletedProxyInfo, *Response, error)
 	DeleteRevision(string, Revision) (*ProxyRevision, *Response, error)
 	Deploy(string, string, Revision, int, bool) (*ProxyRevisionDeployment, *Response, error)
@@ -73,6 +74,11 @@ type ProxyRevision struct {
 	ProxyEndpoints  []string  `json:"proxyEndpoints,omitempty"`
 	Policies        []string  `json:"policies,omitempty"`
 	Type            string    `json:"type,omitempty"`
+}
+
+// ProxyRevisionUpdate only returns the updated revision.
+type ProxyRevisionUpdate struct {
+	Revision Revision `json:"revision,omitempty"`
 }
 
 // ProxyRevisionDeployment holds information about the deployment state of a
@@ -249,40 +255,7 @@ func zipDirectory(source string, target string, filter func(string) bool) error 
 // the path of a zip file containing an API Proxy bundle. Returns the API proxy revision information.
 // This method does not deploy the imported proxy. See the Deploy method.
 func (s *ProxiesServiceOp) Import(proxyName string, source string) (*ProxyRevision, *Response, error) {
-	info, err := os.Stat(source)
-	if err != nil {
-		return nil, nil, err
-	}
-	zipfileName := source
-
-	log.Printf("[INFO] *** Import *** isDir: %#v\n", info.IsDir())
-
-	if info.IsDir() {
-		// create a temporary zip file
-		if proxyName == "" {
-			proxyName = filepath.Base(source)
-		}
-		log.Printf("[INFO] *** Import *** proxyName: %#v\n", proxyName)
-		tempDir, e := ioutil.TempDir("", "go-apigee-edge-")
-		if e != nil {
-			log.Printf("[ERROR] *** Import *** error: %#v\n", e)
-			return nil, nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
-		}
-		log.Printf("[INFO] *** Import *** tempDir: %#v\n", tempDir)
-		log.Printf("[INFO] *** Import *** sourceDir: %#v\n", source)
-		zipfileName = path.Join(tempDir, "apiproxy.zip")
-		e = zipDirectory(path.Join(source, "apiproxy"), zipfileName, smartFilter)
-		if e != nil {
-			return nil, nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
-		}
-		log.Printf("[INFO] *** zipped %s into %s\n\n", source, zipfileName)
-	}
-
-	if !strings.HasSuffix(zipfileName, ".zip") {
-		return nil, nil, errors.New("source must be a zipfile")
-	}
-
-	info, err = os.Stat(zipfileName)
+	ioreader, err := getZip(proxyName, "Import", source)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -298,12 +271,6 @@ func (s *ProxiesServiceOp) Import(proxyName string, source string) (*ProxyRevisi
 	origURL.RawQuery = q.Encode()
 	path := origURL.String()
 
-	ioreader, err := os.Open(zipfileName)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer ioreader.Close()
-
 	req, e := s.client.NewRequest("POST", path, ioreader, "")
 	if e != nil {
 		return nil, nil, e
@@ -314,6 +281,76 @@ func (s *ProxiesServiceOp) Import(proxyName string, source string) (*ProxyRevisi
 		return nil, resp, e
 	}
 	return &returnedProxyRevision, resp, e
+}
+
+// Update an API proxy revision that already exists.
+// The source can be either a filesystem directory containing an exploded apiproxy bundle, OR
+// the path of a zip file containing an API Proxy bundle. Returns the API proxy revision.
+func (s *ProxiesServiceOp) Update(proxyName string, rev Revision, source string) (*ProxyRevisionUpdate, *Response, error) {
+	path := path.Join(proxiesPath, proxyName, "revisions", fmt.Sprintf("%d", rev))
+
+	ioreader, err := getZip(proxyName, "Update", source)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, e := s.client.NewRequest("POST", path, ioreader, "multipart/form-data")
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedProxyRevision := ProxyRevisionUpdate{}
+	resp, e := s.client.Do(req, &returnedProxyRevision)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedProxyRevision, resp, e
+}
+
+// Checks a source directory and creates a ZIP file.
+func getZip(proxyName string, method string, source string) (*os.File, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, err
+	}
+	zipfileName := source
+
+	log.Printf("[INFO] *** %s *** isDir: %#v\n", method, info.IsDir())
+
+	if info.IsDir() {
+		// create a temporary zip file
+		if proxyName == "" {
+			proxyName = filepath.Base(source)
+		}
+		log.Printf("[INFO] *** %s *** proxyName: %#v\n", method, proxyName)
+		tempDir, e := ioutil.TempDir("", "go-apigee-edge-")
+		if e != nil {
+			log.Printf("[ERROR] *** %s *** error: %#v\n", method, e)
+			return nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
+		}
+		log.Printf("[INFO] *** %s *** tempDir: %#v\n", method, tempDir)
+		log.Printf("[INFO] *** %s *** sourceDir: %#v\n", method, source)
+		zipfileName = path.Join(tempDir, "apiproxy.zip")
+		e = zipDirectory(path.Join(source, "apiproxy"), zipfileName, smartFilter)
+		if e != nil {
+			return nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
+		}
+		log.Printf("[INFO] *** zipped %s into %s\n\n", source, zipfileName)
+	}
+
+	if !strings.HasSuffix(zipfileName, ".zip") {
+		return nil, errors.New("source must be a zipfile")
+	}
+
+	info, err = os.Stat(zipfileName)
+	if err != nil {
+		return nil, err
+	}
+
+	ioreader, err := os.Open(zipfileName)
+	if err != nil {
+		return nil, err
+	}
+	defer ioreader.Close()
+	return ioreader, nil
 }
 
 // Export a revision of an API proxy within an organization, to a filesystem file.


### PR DESCRIPTION
Tested. Seems to work. 

This adds the endpoint:
https://apidocs.apigee.com/management/apis/post/organizations/%7Borg_name%7D/apis/%7Bapi_name%7D/revisions/%7Brevision_number%7D-0

I needed this in order to properly mess with terraform.