### PR TITLE
Company app keys support

### DIFF
--- a/apigee_edge.go
+++ b/apigee_edge.go
@@ -44,14 +44,15 @@ type EdgeClient struct {
 	UserAgent string
 
 	// Services used for communicating with the API
-	Proxies       ProxiesService
-	TargetServers TargetServersService
-	Products      ProductsService
-	Developers    DeveloperService
-	Companies     CompanyService
-	CompanyApps   CompanyAppService
-	DeveloperApps DeveloperAppService
-	SharedFlows   SharedFlowService
+	Proxies               ProxiesService
+	TargetServers         TargetServersService
+	Products              ProductsService
+	Developers            DeveloperService
+	Companies             CompanyService
+	CompanyApps           CompanyAppService
+	CompanyAppCredentials CompanyAppCredentialService
+	DeveloperApps         DeveloperAppService
+	SharedFlows           SharedFlowService
 
 	// Account           AccountService
 	// Actions           ActionsService
@@ -199,6 +200,7 @@ func NewEdgeClient(o *EdgeClientOptions) (*EdgeClient, error) {
 	c.Developers = &DeveloperServiceOp{client: c}
 	c.Companies = &CompanyServiceOp{client: c}
 	c.CompanyApps = &CompanyAppServiceOp{client: c}
+	c.CompanyAppCredentials = &CompanyAppCredentialServiceOp{client: c}
 	c.DeveloperApps = &DeveloperAppServiceOp{client: c}
 	c.SharedFlows = &SharedFlowServiceOp{client: c}
 

--- a/common.go
+++ b/common.go
@@ -18,6 +18,7 @@ type Credential struct {
 	ExpiresAt      int                    `json:"expiresAt,omitempty"`
 	IssuedAt       int                    `json:"issuedAt,omitempty"`
 	Scopes         []string               `json:"scopes,omitempty"`
+	Status         string                 `json:"status,omitempty"`
 }
 
 //This is just a placeholder

--- a/company_app_credential.go
+++ b/company_app_credential.go
@@ -1,0 +1,123 @@
+package apigee
+
+import (
+	"path"
+)
+
+// CompanyAppCredentialService is an interface for interfacing with the Apigee Edge Admin API
+// dealing with companyApp credentials.
+type CompanyAppCredentialService interface {
+	Create(string, string, CompanyAppCredential) (*Credential, *Response, error)
+	Update(string, string, string, CompanyAppCredential) (*Credential, *Response, error)
+	Get(string, string, string) (*Credential, *Response, error)
+	Delete(string, string, string) (*Response, error)
+	RemoveApiProduct(string, string, string, string) (*Response, error)
+}
+
+type CompanyAppCredentialServiceOp struct {
+	client *EdgeClient
+}
+
+var _ CompanyAppCredentialService = &CompanyAppCredentialServiceOp{}
+
+type CompanyAppCredential struct {
+	ConsumerKey    string      `json:"consumerKey,omitempty"`
+	ConsumerSecret string      `json:"consumerSecret,omitempty"`
+	ApiProducts    []string    `json:"apiProducts,omitempty"`
+	ExpiresAt      int         `json:"expiresAt,omitempty"`
+	Attributes     []Attribute `json:"attributes,omitempty"`
+	Scopes         []string    `json:"scopes,omitempty"`
+}
+
+func (s *CompanyAppCredentialServiceOp) Create(companyName string, appName string, companyAppCredential CompanyAppCredential) (*Credential, *Response, error) {
+
+	uripath := path.Join("companies", companyName, "apps", appName, "keys", "create")
+
+	req, e := s.client.NewRequest("POST", uripath, companyAppCredential, "")
+	if e != nil {
+		return nil, nil, e
+	}
+
+	returnedCompanyAppCredentials := Credential{}
+
+	resp, e := s.client.Do(req, &returnedCompanyAppCredentials)
+	if e != nil {
+		return nil, resp, e
+	}
+
+	return &returnedCompanyAppCredentials, resp, e
+
+}
+
+func (s *CompanyAppCredentialServiceOp) Update(companyName string, appName string, consumerKey string, companyAppCredential CompanyAppCredential) (*Credential, *Response, error) {
+
+	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey)
+
+	req, e := s.client.NewRequest("POST", uripath, companyAppCredential, "")
+	if e != nil {
+		return nil, nil, e
+	}
+
+	returnedCompanyAppCredentials := Credential{}
+
+	resp, e := s.client.Do(req, &returnedCompanyAppCredentials)
+	if e != nil {
+		return nil, resp, e
+	}
+
+	return &returnedCompanyAppCredentials, resp, e
+
+}
+
+func (s *CompanyAppCredentialServiceOp) Get(companyName string, appName string, consumerKey string) (*Credential, *Response, error) {
+
+	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey)
+
+	req, e := s.client.NewRequest("GET", uripath, nil, "")
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedCompanyAppCredential := Credential{}
+	resp, e := s.client.Do(req, &returnedCompanyAppCredential)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedCompanyAppCredential, resp, e
+
+}
+
+func (s *CompanyAppCredentialServiceOp) Delete(companyName string, appName string, consumerKey string) (*Response, error) {
+
+	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey)
+
+	req, e := s.client.NewRequest("DELETE", uripath, nil, "")
+	if e != nil {
+		return nil, e
+	}
+
+	resp, e := s.client.Do(req, nil)
+	if e != nil {
+		return resp, e
+	}
+
+	return resp, e
+
+}
+
+func (s *CompanyAppCredentialServiceOp) RemoveApiProduct(companyName string, appName string, consumerKey string, apiProductName string) (*Response, error) {
+
+	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey, "apiproducts", apiProductName)
+
+	req, e := s.client.NewRequest("DELETE", uripath, nil, "")
+	if e != nil {
+		return nil, e
+	}
+
+	resp, e := s.client.Do(req, nil)
+	if e != nil {
+		return resp, e
+	}
+
+	return resp, e
+
+}

--- a/company_app_credential.go
+++ b/company_app_credential.go
@@ -5,7 +5,7 @@ import (
 )
 
 // CompanyAppCredentialService is an interface for interfacing with the Apigee Edge Admin API
-// dealing with companyApp credentials.
+// dealing with companyApp credentials/keys.
 type CompanyAppCredentialService interface {
 	Create(string, string, CompanyAppCredential) (*Credential, *Response, error)
 	Update(string, string, string, CompanyAppCredential) (*Credential, *Response, error)
@@ -29,6 +29,7 @@ type CompanyAppCredential struct {
 	Scopes         []string    `json:"scopes,omitempty"`
 }
 
+// Create a company app's consumer key and secret
 func (s *CompanyAppCredentialServiceOp) Create(companyName string, appName string, companyAppCredential CompanyAppCredential) (*Credential, *Response, error) {
 
 	uripath := path.Join("companies", companyName, "apps", appName, "keys", "create")
@@ -49,6 +50,7 @@ func (s *CompanyAppCredentialServiceOp) Create(companyName string, appName strin
 
 }
 
+// Update existing company app's consumer key with new API products or attributes
 func (s *CompanyAppCredentialServiceOp) Update(companyName string, appName string, consumerKey string, companyAppCredential CompanyAppCredential) (*Credential, *Response, error) {
 
 	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey)
@@ -69,6 +71,7 @@ func (s *CompanyAppCredentialServiceOp) Update(companyName string, appName strin
 
 }
 
+// Get information about a company app's consumer key
 func (s *CompanyAppCredentialServiceOp) Get(companyName string, appName string, consumerKey string) (*Credential, *Response, error) {
 
 	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey)
@@ -86,6 +89,7 @@ func (s *CompanyAppCredentialServiceOp) Get(companyName string, appName string, 
 
 }
 
+// Delete a company app's consumer key
 func (s *CompanyAppCredentialServiceOp) Delete(companyName string, appName string, consumerKey string) (*Response, error) {
 
 	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey)
@@ -104,6 +108,7 @@ func (s *CompanyAppCredentialServiceOp) Delete(companyName string, appName strin
 
 }
 
+// Remove an API product from a company app's consumer key
 func (s *CompanyAppCredentialServiceOp) RemoveApiProduct(companyName string, appName string, consumerKey string, apiProductName string) (*Response, error) {
 
 	uripath := path.Join("companies", companyName, "apps", appName, "keys", consumerKey, "apiproducts", apiProductName)


### PR DESCRIPTION
This adds support to the below company app keys/credentials endpoints -

- Create a company app's consumer key and secret
- Update existing company app's consumer key with new API products or attributes
- Get information about a company app's consumer key
- Delete a company app's consumer key
- Remove an API product from a company app's consumer key

https://apidocs.apigee.com/api/company-app-keys-0