### PR TITLE
base path correction to support up-to-date Apigee version

### DIFF
--- a/apigee_edge.go
+++ b/apigee_edge.go
@@ -192,7 +192,7 @@ func NewEdgeClient(o *EdgeClientOptions) (*EdgeClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	baseURL.Path = path.Join(baseURL.Path, "v1/o/", o.Org, "/")
+	baseURL.Path = path.Join(baseURL.Path, "v1/organizations/", o.Org, "/")
 
 	c := &EdgeClient{client: *pesterClient, BaseURL: baseURL, UserAgent: userAgent}
 	c.Proxies = &ProxiesServiceOp{client: c}


### PR DESCRIPTION
I just realised that the `basePath` has slightly changed e.g. for Apigee X. Moreover the documentation for Apigee Edge also indicates `https://api.enterprise.apigee.com/v1/organizations/...` to be correct. 

That change, used in zambien/terraform-provider-apigee would make the Terraform provider work with Apigee X again.

References: 
- https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli#deploy-proxy
- https://docs.apigee.com/api-platform/fundamentals/developing-apigee-edge?hl=de#usingtherestfulmanagementapi-understandingthebasepath