### PR TITLE
export filename using proxy name

### DIFF
--- a/proxies.go
+++ b/proxies.go
@@ -384,8 +384,8 @@ func (s *ProxiesServiceOp) Export(proxyName string, rev Revision) (string, *Resp
 	req.Header.Del("Accept")
 
 	t := time.Now()
-	filename := fmt.Sprintf("proxyName-r%d-%d%02d%02d-%02d%02d%02d.zip",
-		rev, t.Year(), t.Month(), t.Day(),
+	filename := fmt.Sprintf("%s-r%d-%d%02d%02d-%02d%02d%02d.zip",
+		proxyName, rev, t.Year(), t.Month(), t.Day(),
 		t.Hour(), t.Minute(), t.Second())
 
 	out, e := os.Create(filename)


### PR DESCRIPTION
This is maybe a small change, use the value from proxyName instead of the literal string "proxyName" in the name of the resulting zip file from the `Export()` call.

Would potentially be a breaking change if you're relying on the filename in other scripts, but hopefully are using the return value of the filename.